### PR TITLE
Batiai 762 - revision 2 of sdl ingestion code

### DIFF
--- a/sdl_logs/README.md
+++ b/sdl_logs/README.md
@@ -1,0 +1,4 @@
+# SDL logs
+
+Sends all object create events on the logging bucket to eventbridge, a trigger to SNS, and connection to the Panther SQS queue for ingestion.
+

--- a/sdl_logs/eventbridge.tf
+++ b/sdl_logs/eventbridge.tf
@@ -1,0 +1,58 @@
+
+resource "aws_cloudwatch_event_rule" "rule" {
+  name        = "logs-to-panther"
+  description = "Sends bucket object create events to SNS"
+
+  event_pattern = <<EOF
+{
+  "source": [
+    "aws.s3"
+  ],
+  "detail-type": [
+    "Object Created"
+  ],
+  "detail": {
+  	"bucket": {
+        "name": ["${data.aws_s3_bucket.cms_logging_bucket.id}"]
+    }
+  }
+}
+EOF
+}
+
+resource "aws_cloudwatch_event_target" "target" {
+  rule      = aws_cloudwatch_event_rule.rule.name
+  target_id = aws_cloudwatch_event_rule.rule.name
+  arn       = aws_sns_topic.panther_topic.id
+
+  input_transformer {
+    input_paths = {
+      bucket  = "$.detail.bucket.name",
+      object  = "$.detail.object",
+      region  = "$.region"
+      time    = "$.time"
+      account = "$.account"
+    }
+    input_template = <<EOF
+{
+    "Records": [
+        {
+            "eventVersion":"2.2",
+            "eventSource":"aws:s3",
+            "awsRegion":<region>,
+            "eventTime":<time>,
+            "eventName":"PutObject",
+            "s3":{  
+                "s3SchemaVersion":"1.0",
+                "bucket":{  
+                    "name":"${data.aws_s3_bucket.cms_logging_bucket.id}",
+                    "arn":"${data.aws_s3_bucket.cms_logging_bucket.arn}"
+                },
+                "object": <object>
+            }
+        }
+    ]
+}
+EOF
+  }
+}

--- a/sdl_logs/kms.tf
+++ b/sdl_logs/kms.tf
@@ -1,0 +1,51 @@
+# Cloudtrail KMS key
+data "aws_kms_alias" "cloudtrail_kms_key" {
+  name = "alias/cms-cloud-${data.aws_caller_identity.current.account_id}"
+}
+
+# SNS Topic KMS Key
+data "aws_iam_policy_document" "kms_key" {
+
+  statement {
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*"
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "s3.amazonaws.com",
+        "sns.amazonaws.com",
+        "events.amazonaws.com",
+      ]
+    }
+  }
+}
+
+resource "aws_kms_key" "kms_key" {
+  deletion_window_in_days = 7
+  description             = "batCAVE Panther SNS Topic KMS Key"
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.kms_key.json
+
+}
+
+resource "aws_kms_alias" "kms_key" {
+  name          = "alias/batcave-panther"
+  target_key_id = aws_kms_key.kms_key.id
+}

--- a/sdl_logs/main.tf
+++ b/sdl_logs/main.tf
@@ -86,24 +86,3 @@ resource "aws_iam_role_policy" "kms_decryption" {
   })
 }
 
-# Provides an IAM role inline policy for reading and adding notification configuration of a bucket
-resource "aws_iam_role_policy" "managed_bucket_notifications_policy" {
-  count = var.managed_bucket_notifications_enabled ? 1 : 0
-  name  = "GetPutBucketNotifications"
-  role  = aws_iam_role.log_processing_role.id
-  policy = jsonencode({
-    Version : "2012-10-17",
-    Statement : [
-      {
-        Effect : "Allow",
-        Action : [
-          "s3:GetBucketNotification",
-          "s3:PutBucketNotification",
-        ],
-        Resource : [
-          data.aws_s3_bucket.cms_logging_bucket.arn,
-        ]
-      }
-    ]
-  })
-}

--- a/sdl_logs/main.tf
+++ b/sdl_logs/main.tf
@@ -1,0 +1,109 @@
+# Copyright (C) 2022 Panther Labs Inc
+#
+# Panther Enterprise is licensed under the terms of a commercial license available from
+# Panther Labs Inc ("Panther Commercial License") by contacting contact@runpanther.com.
+# All use, distribution, and/or modification of this software, whether commercial or non-commercial,
+# falls under the Panther Commercial License to the extent it is permitted.
+
+data "aws_caller_identity" "current" {}
+
+# IAM roles for log ingestion from an S3 bucket
+resource "aws_iam_role" "log_processing_role" {
+  name = "PantherLogProcessingRole-${var.role_suffix}"
+
+  path                 = var.role_path
+  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/cms-cloud-admin/developer-boundary-policy"
+
+  # Policy that grants an entity permission to assume the role.
+  assume_role_policy = jsonencode({
+    Version : "2012-10-17",
+    Statement : [
+      {
+        Action : "sts:AssumeRole",
+        Effect : "Allow",
+        Principal : {
+          AWS : "arn:${var.aws_partition}:iam::${var.panther_aws_account_id}:root"
+        }
+        Condition : {
+          Bool : { "aws:SecureTransport" : true }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Application = "Panther"
+  }
+}
+
+
+# Provides an IAM role inline policy for reading s3 Data
+resource "aws_iam_role_policy" "read_data_policy" {
+  name = "ReadData"
+  role = aws_iam_role.log_processing_role.id
+  policy = jsonencode({
+    Version : "2012-10-17",
+    Statement : [
+      {
+        Effect : "Allow",
+        Action : [
+          "s3:GetBucketLocation",
+          "s3:ListBucket",
+        ],
+        Resource : [
+          data.aws_s3_bucket.cms_logging_bucket.arn,
+        ]
+      },
+      {
+        Effect : "Allow",
+        Action : "s3:GetObject",
+        Resource : [
+          "${data.aws_s3_bucket.cms_logging_bucket.arn}/*",
+        ]
+    }, ]
+  })
+}
+
+# Provides an ARN that decrypts ciphertext that was encrypted by a KMS key
+resource "aws_iam_role_policy" "kms_decryption" {
+  name = "kmsDecryption"
+  role = aws_iam_role.log_processing_role.id
+  policy = jsonencode({
+    Version : "2012-10-17",
+    Statement : [
+      {
+        Effect : "Allow",
+        Action : [
+          "kms:Decrypt",
+          "kms:DescribeKey"
+        ],
+        Resource : [
+          aws_kms_key.kms_key.arn,
+          data.aws_kms_alias.cloudtrail_kms_key.target_key_arn,
+        ]
+      }
+    ]
+  })
+}
+
+# Provides an IAM role inline policy for reading and adding notification configuration of a bucket
+resource "aws_iam_role_policy" "managed_bucket_notifications_policy" {
+  count = var.managed_bucket_notifications_enabled ? 1 : 0
+  name  = "GetPutBucketNotifications"
+  role  = aws_iam_role.log_processing_role.id
+  policy = jsonencode({
+    Version : "2012-10-17",
+    Statement : [
+      {
+        Effect : "Allow",
+        Action : [
+          "s3:GetBucketNotification",
+          "s3:PutBucketNotification",
+        ],
+        Resource : [
+          data.aws_s3_bucket.cms_logging_bucket.arn,
+        ]
+      }
+    ]
+  })
+}

--- a/sdl_logs/outputs.tf
+++ b/sdl_logs/outputs.tf
@@ -1,0 +1,11 @@
+# Copyright (C) 2022 Panther Labs Inc
+#
+# Panther Enterprise is licensed under the terms of a commercial license available from
+# Panther Labs Inc ("Panther Commercial License") by contacting contact@runpanther.com.
+# All use, distribution, and/or modification of this software, whether commercial or non-commercial,
+# falls under the Panther Commercial License to the extent it is permitted.
+
+output "role_arn" {
+  value       = aws_iam_role.log_processing_role.arn
+  description = "The ARN of the log processing role that Panther will use to read S3 objects."
+}

--- a/sdl_logs/s3.tf
+++ b/sdl_logs/s3.tf
@@ -1,0 +1,29 @@
+data "aws_s3_bucket" "cms_logging_bucket" {
+  bucket = "cms-cloud-${data.aws_caller_identity.current.account_id}-us-east-1"
+}
+
+# resource "aws_s3_bucket_notification" "bucket_notification" {
+#   bucket      = data.aws_s3_bucket.cms_logging_bucket.id
+#   eventbridge = true
+# }
+
+# Bucket notifications are managed as a single resource by AWS. 
+# If an organizational change is made from cms cloud, our notifications will be overwritten, and if we
+# make a change, we overwrite their settings, so this became a last resort
+# This local-exec requires aws cli on the local machine
+# Grabs the current bucket notification configuration and ensures
+# .EventBridgeConfiguration = {} is present. An empty JSON object means this setting is enabled.
+resource "null_resource" "bucket_notification" {
+  triggers = {
+    notification_configuration = data.external.bucket_notification.result["eventbridge"]
+  }
+  provisioner "local-exec" {
+    command = tobool(data.external.bucket_notification.result["eventbridge"]) ? "echo blank" :"aws s3api put-bucket-notification-configuration --bucket ${data.aws_s3_bucket.cms_logging_bucket.id} --notification-configuration \"$(aws s3api get-bucket-notification-configuration --bucket ${data.aws_s3_bucket.cms_logging_bucket.id} --output json | jq '.EventBridgeConfiguration = {}')\""
+  }
+}
+
+# this has some custom jq because the external provider cant deal with arrays in json objects and lambdaconfig is an array
+# it is the trigger for the bucket notification code above to check if it needs to overwrite
+data "external" "bucket_notification" {
+program = ["sh", "-c", "aws s3api get-bucket-notification-configuration --bucket ${data.aws_s3_bucket.cms_logging_bucket.id} --output json | jq -r '.EventBridgeConfiguration |if .==null then {\"eventbridge\":\"false\"} else {\"eventbridge\":\"true\"} end'"]
+}

--- a/sdl_logs/s3.tf
+++ b/sdl_logs/s3.tf
@@ -2,10 +2,6 @@ data "aws_s3_bucket" "cms_logging_bucket" {
   bucket = "cms-cloud-${data.aws_caller_identity.current.account_id}-us-east-1"
 }
 
-# resource "aws_s3_bucket_notification" "bucket_notification" {
-#   bucket      = data.aws_s3_bucket.cms_logging_bucket.id
-#   eventbridge = true
-# }
 
 # Bucket notifications are managed as a single resource by AWS. 
 # If an organizational change is made from cms cloud, our notifications will be overwritten, and if we
@@ -18,12 +14,12 @@ resource "null_resource" "bucket_notification" {
     notification_configuration = data.external.bucket_notification.result["eventbridge"]
   }
   provisioner "local-exec" {
-    command = tobool(data.external.bucket_notification.result["eventbridge"]) ? "echo blank" :"aws s3api put-bucket-notification-configuration --bucket ${data.aws_s3_bucket.cms_logging_bucket.id} --notification-configuration \"$(aws s3api get-bucket-notification-configuration --bucket ${data.aws_s3_bucket.cms_logging_bucket.id} --output json | jq '.EventBridgeConfiguration = {}')\""
+    command = tobool(data.external.bucket_notification.result["eventbridge"]) ? "echo blank" : "aws s3api put-bucket-notification-configuration --bucket ${data.aws_s3_bucket.cms_logging_bucket.id} --notification-configuration \"$(aws s3api get-bucket-notification-configuration --bucket ${data.aws_s3_bucket.cms_logging_bucket.id} --output json | jq '.EventBridgeConfiguration = {}')\""
   }
 }
 
 # this has some custom jq because the external provider cant deal with arrays in json objects and lambdaconfig is an array
 # it is the trigger for the bucket notification code above to check if it needs to overwrite
 data "external" "bucket_notification" {
-program = ["sh", "-c", "aws s3api get-bucket-notification-configuration --bucket ${data.aws_s3_bucket.cms_logging_bucket.id} --output json | jq -r '.EventBridgeConfiguration |if .==null then {\"eventbridge\":\"false\"} else {\"eventbridge\":\"true\"} end'"]
+  program = ["sh", "-c", "aws s3api get-bucket-notification-configuration --bucket ${data.aws_s3_bucket.cms_logging_bucket.id} --output json | jq -r '.EventBridgeConfiguration |if .==null then {\"eventbridge\":\"false\"} else {\"eventbridge\":\"true\"} end'"]
 }

--- a/sdl_logs/sns.tf
+++ b/sdl_logs/sns.tf
@@ -1,0 +1,109 @@
+resource "aws_sns_topic" "panther_topic" {
+  name              = "panther-notifications-topic"
+  kms_master_key_id = aws_kms_alias.kms_key.arn
+}
+
+resource "aws_sns_topic_policy" "default" {
+  arn = aws_sns_topic.panther_topic.arn
+
+  policy = data.aws_iam_policy_document.sns_topic_policy.json
+}
+
+data "aws_iam_policy_document" "sns_topic_policy" {
+  policy_id = "__default_policy_ID"
+
+  statement {
+    actions = [
+      "sns:Subscribe",
+      "sns:SetTopicAttributes",
+      "sns:Receive",
+      "sns:ListSubscriptionsByTopic",
+      "sns:GetTopicAttributes",
+      "sns:AddPermission",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceOwner"
+
+      values = [
+        data.aws_caller_identity.current.account_id,
+      ]
+    }
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      aws_sns_topic.panther_topic.arn,
+    ]
+
+    sid = "sns"
+
+  }
+
+  statement {
+    actions = [
+      "sns:Subscribe",
+      "sns:Receive",
+      "sns:GetTopicAttributes",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceOwner"
+
+      values = [
+        var.panther_aws_account_id,
+      ]
+    }
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      "arn:aws:sqs:us-east-1:${var.panther_aws_account_id}:panther-input-data-notifications-queue",
+    ]
+
+    sid = "lambda"
+
+  }
+
+  statement {
+    actions = [
+      "sns:Publish",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = [
+        "s3.amazonaws.com",
+        "events.amazonaws.com",
+      ]
+    }
+
+    resources = [
+      aws_sns_topic.panther_topic.arn,
+    ]
+
+    sid = "allowS3Events"
+  }
+
+}
+
+# Will panther subscribe it on its own?
+resource "aws_sns_topic_subscription" "panther" {
+  topic_arn = aws_sns_topic.panther_topic.arn
+  protocol  = "sqs"
+  endpoint  = "arn:aws:sqs:us-east-1:${var.panther_aws_account_id}:panther-input-data-notifications-queue"
+}

--- a/sdl_logs/sns.tf
+++ b/sdl_logs/sns.tf
@@ -85,7 +85,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     effect = "Allow"
 
     principals {
-      type        = "Service"
+      type = "Service"
       identifiers = [
         "s3.amazonaws.com",
         "events.amazonaws.com",

--- a/sdl_logs/variables.tf
+++ b/sdl_logs/variables.tf
@@ -23,24 +23,6 @@ variable "role_suffix" {
   description = "A unique identifier that will be used as the IAM role suffix"
 }
 
-variable "accounts_list" {
-  description = "AWS Accounts to onboard"
-  type        = list(string)
-  default     = []
-}
-
-variable "kms_key_arn" {
-  type        = string
-  description = "The ARN of the KMS key if your data is encrypted using KMS-SSE. Not required if using SSE-S3."
-  default     = ""
-}
-
-variable "managed_bucket_notifications_enabled" {
-  type        = bool
-  description = "Allow Panther to configure bucket SNS notifications"
-  default     = true
-}
-
 variable "role_path" {
   type        = string
   description = "Path for IAM Roles and managed policies required."

--- a/sdl_logs/variables.tf
+++ b/sdl_logs/variables.tf
@@ -1,0 +1,48 @@
+# Copyright (C) 2022 Panther Labs Inc
+#
+# Panther Enterprise is licensed under the terms of a commercial license available from
+# Panther Labs Inc ("Panther Commercial License") by contacting contact@runpanther.com.
+# All use, distribution, and/or modification of this software, whether commercial or non-commercial,
+# falls under the Panther Commercial License to the extent it is permitted.
+
+
+
+variable "aws_partition" {
+  type        = string
+  default     = "aws"
+  description = "AWS partition of the account running the Panther backend e.g aws, aws-cn, or aws-us-gov"
+}
+
+variable "panther_aws_account_id" {
+  type        = string
+  description = "The AWS account ID of your Panther instance"
+}
+
+variable "role_suffix" {
+  type        = string
+  description = "A unique identifier that will be used as the IAM role suffix"
+}
+
+variable "accounts_list" {
+  description = "AWS Accounts to onboard"
+  type        = list(string)
+  default     = []
+}
+
+variable "kms_key_arn" {
+  type        = string
+  description = "The ARN of the KMS key if your data is encrypted using KMS-SSE. Not required if using SSE-S3."
+  default     = ""
+}
+
+variable "managed_bucket_notifications_enabled" {
+  type        = bool
+  description = "Allow Panther to configure bucket SNS notifications"
+  default     = true
+}
+
+variable "role_path" {
+  type        = string
+  description = "Path for IAM Roles and managed policies required."
+  default     = "/delegatedadmin/developer/"
+}


### PR DESCRIPTION
[jira ticket](https://jiraent.cms.gov/browse/BATIAI-762)

Adds SDL ingestion code, will delete whats in gitlab. 

- Enables S3 eventbridge integration ( uses a null_resource, but it was the absolute last possibility )
- Creates event trigger and rule
- reformats alert to match normal event notification schema
- sends alerts to SNS topic
- SNS topic is subscribed to panther SQS queue for ingestion
- IAM role with trust to panther account