### PR TITLE
add account alias module

### DIFF
--- a/account_alias/README.md
+++ b/account_alias/README.md
@@ -1,0 +1,5 @@
+# account_alias
+
+Sets the account alias for an AWS account. https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html
+
+Variable account_alias will be set for the account, e.g. "batcave-dev". Queryable with [ListAccountAliases](https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListAccountAliases.html)

--- a/account_alias/main.tf
+++ b/account_alias/main.tf
@@ -1,0 +1,12 @@
+resource "aws_iam_account_alias" "alias" {
+  account_alias = var.alias_name
+}
+
+variable "alias_name" {
+  type        = string
+  description = "This is the alias name that will be set."
+  validation {
+    condition     = length(var.alias_name) >= 3 && length(var.alias_name) <= 63
+    error_message = "Account Alias must have between 3 and 63 characters."
+  }
+}


### PR DESCRIPTION
Adds a module for account alias.

We would set account alias like "batcave-dev" on the account and then be able to query it easily.