### PR TITLE
fix: remove old nessus rule

### DIFF
--- a/security-alerts/events.tf
+++ b/security-alerts/events.tf
@@ -32,39 +32,6 @@ resource "aws_cloudwatch_event_target" "target" {
   arn       = aws_sns_topic.slack_topic.id
 }
 
-# Security hub nessus only
-resource "aws_cloudwatch_event_rule" "nessus" {
-  name        = "sechub-findings-to-lambda-nessus"
-  description = "Sends Security Hub nessus findings to a Slack Lambda"
-
-  event_pattern = <<EOF
-{
-  "source": [
-    "aws.securityhub"
-  ],
-  "detail-type": [
-    "Security Hub Findings - Imported"
-  ],
-  "detail": {
-    "findings": {
-      "RecordState": ["ACTIVE"],
-      "WorkflowState": ["NEW"],
-      "Severity": {
-        "Label": [ "CRITICAL" ]
-      },
-      "ProductName": [ "Default" ]
-    }
-  }
-}
-EOF
-}
-
-resource "aws_cloudwatch_event_target" "nessus" {
-  rule      = aws_cloudwatch_event_rule.nessus.name
-  target_id = aws_cloudwatch_event_rule.nessus.name
-  arn       = aws_sns_topic.slack_topic.id
-}
-
 # GuardDuty
 resource "aws_cloudwatch_event_rule" "guardduty" {
   name        = "guardduty-findings-to-lambda"


### PR DESCRIPTION
## Fixes Issue
[BATSAD-937](https://jiraent.cms.gov/browse/BATSAD-937)

## Description: 
Removes Eventbridge rule matching SecurityHub Nessus vulnerability scan events. Sending the individual events to the channel is too noisy for human consumption. We will be migrating these to a daily generated report with additional context information.


## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [X] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.
