### PR TITLE
Feat: Add State Machine to properly dedup securityhub findings

### DIFF
--- a/security-alerts/data.tf
+++ b/security-alerts/data.tf
@@ -1,0 +1,1 @@
+data "aws_region" "current" {}

--- a/security-alerts/events.tf
+++ b/security-alerts/events.tf
@@ -30,6 +30,7 @@ resource "aws_cloudwatch_event_target" "target" {
   rule      = aws_cloudwatch_event_rule.rule.name
   target_id = aws_cloudwatch_event_rule.rule.name
   arn       = aws_sfn_state_machine.sechub_state_machine.arn
+  role_arn      = aws_iam_role.sfn_target_role.arn
 }
 
 # Security hub nessus only
@@ -63,6 +64,7 @@ resource "aws_cloudwatch_event_target" "nessus" {
   rule      = aws_cloudwatch_event_rule.nessus.name
   target_id = aws_cloudwatch_event_rule.nessus.name
   arn       = aws_sfn_state_machine.sechub_state_machine.arn
+  role_arn      = aws_iam_role.sfn_target_role.arn
 }
 
 # GuardDuty

--- a/security-alerts/events.tf
+++ b/security-alerts/events.tf
@@ -1,8 +1,8 @@
 # Security hub generic
 resource "aws_cloudwatch_event_rule" "rule" {
-  name        = "sechub-findings-to-lambda"
-  description = "Sends Security Hub findings to a Slack Lambda"
-
+  name          = "sechub-findings-to-lambda"
+  description   = "Sends Security Hub findings to a Slack Lambda"
+  role_arn      = aws_iam_role.sfn_target_role.arn
   event_pattern = <<EOF
 {
   "source": [
@@ -34,9 +34,9 @@ resource "aws_cloudwatch_event_target" "target" {
 
 # Security hub nessus only
 resource "aws_cloudwatch_event_rule" "nessus" {
-  name        = "sechub-findings-to-lambda-nessus"
-  description = "Sends Security Hub nessus findings to a Slack Lambda"
-
+  name          = "sechub-findings-to-lambda-nessus"
+  description   = "Sends Security Hub nessus findings to a Slack Lambda"
+  role_arn      = aws_iam_role.sfn_target_role.arn
   event_pattern = <<EOF
 {
   "source": [

--- a/security-alerts/events.tf
+++ b/security-alerts/events.tf
@@ -29,7 +29,7 @@ EOF
 resource "aws_cloudwatch_event_target" "target" {
   rule      = aws_cloudwatch_event_rule.rule.name
   target_id = aws_cloudwatch_event_rule.rule.name
-  arn       = aws_sns_topic.slack_topic.id
+  arn       = aws_sfn_state_machine.sechub_state_machine
 }
 
 # Security hub nessus only
@@ -62,7 +62,7 @@ EOF
 resource "aws_cloudwatch_event_target" "nessus" {
   rule      = aws_cloudwatch_event_rule.nessus.name
   target_id = aws_cloudwatch_event_rule.nessus.name
-  arn       = aws_sns_topic.slack_topic.id
+  arn       = aws_sfn_state_machine.sechub_state_machine
 }
 
 # GuardDuty

--- a/security-alerts/events.tf
+++ b/security-alerts/events.tf
@@ -30,7 +30,7 @@ resource "aws_cloudwatch_event_target" "target" {
   rule      = aws_cloudwatch_event_rule.rule.name
   target_id = aws_cloudwatch_event_rule.rule.name
   arn       = aws_sfn_state_machine.sechub_state_machine.arn
-  role_arn      = aws_iam_role.sfn_target_role.arn
+  role_arn  = aws_iam_role.sfn_target_role.arn
 }
 
 # Security hub nessus only
@@ -64,7 +64,7 @@ resource "aws_cloudwatch_event_target" "nessus" {
   rule      = aws_cloudwatch_event_rule.nessus.name
   target_id = aws_cloudwatch_event_rule.nessus.name
   arn       = aws_sfn_state_machine.sechub_state_machine.arn
-  role_arn      = aws_iam_role.sfn_target_role.arn
+  role_arn  = aws_iam_role.sfn_target_role.arn
 }
 
 # GuardDuty

--- a/security-alerts/events.tf
+++ b/security-alerts/events.tf
@@ -29,7 +29,7 @@ EOF
 resource "aws_cloudwatch_event_target" "target" {
   rule      = aws_cloudwatch_event_rule.rule.name
   target_id = aws_cloudwatch_event_rule.rule.name
-  arn       = aws_sfn_state_machine.sechub_state_machine
+  arn       = aws_sfn_state_machine.sechub_state_machine.arn
 }
 
 # Security hub nessus only
@@ -62,7 +62,7 @@ EOF
 resource "aws_cloudwatch_event_target" "nessus" {
   rule      = aws_cloudwatch_event_rule.nessus.name
   target_id = aws_cloudwatch_event_rule.nessus.name
-  arn       = aws_sfn_state_machine.sechub_state_machine
+  arn       = aws_sfn_state_machine.sechub_state_machine.arn
 }
 
 # GuardDuty

--- a/security-alerts/iam.tf
+++ b/security-alerts/iam.tf
@@ -92,7 +92,7 @@ resource "aws_iam_role" "sfn_sechub_role" {
         Action : "sts:AssumeRole",
         Condition : {
           ArnLike : {
-            "aws:SourceArn" : aws_sfn_state_machine.sechub_state_machine.arn
+            "aws:SourceArn" : "arn:aws:states:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.step_function_name}"
           },
           StringEquals : {
             "aws:SourceAccount" : "${data.aws_caller_identity.current.account_id}"
@@ -130,8 +130,8 @@ data "aws_iam_policy_document" "sfn_sechub_policy" {
       "kms:Decrypt",
       "kms:GenerateDataKey*"
     ]
-    resource = [
-      aws_kms_key.aws_kms_key.arn
+    resources = [
+      aws_kms_key.kms_key.arn
     ]
   }
 }

--- a/security-alerts/iam.tf
+++ b/security-alerts/iam.tf
@@ -136,6 +136,19 @@ data "aws_iam_policy_document" "sfn_sechub_policy" {
   }
 }
 
+resource "aws_iam_role_policy_attachment" "sfn_sechub_attach" {
+  role       = aws_iam_role.sfn_sechub_role.name
+  policy_arn = aws_iam_policy.sfn_sechub_policy.arn
+}
+
+resource "aws_iam_policy" "sfn_sechub_policy" {
+  name        = "sfn_sechub_policy"
+  path        = var.iam_role_path
+  description = "Allows the SecHub step funcion to publish to our sns topic"
+
+  policy = data.aws_iam_policy_document.sfn_sechub_policy.json
+}
+
 # eventbridge sfn target role
 
 resource "aws_iam_role" "sfn_target_role" {
@@ -176,4 +189,17 @@ data "aws_iam_policy_document" "sfn_target_policy" {
     ]
     resources = ["arn:aws:states:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.step_function_name}"]
   }
+}
+
+resource "aws_iam_role_policy_attachment" "sfn_target_attach" {
+  role       = aws_iam_role.sfn_target_role.name
+  policy_arn = aws_iam_policy.sfn_target_policy.arn
+}
+
+resource "aws_iam_policy" "sfn_target_policy" {
+  name        = "sfn_target_policy"
+  path        = var.iam_role_path
+  description = "Allows Eventbridge Rules to invoke the SecHub findings state machine"
+
+  policy = data.aws_iam_policy_document.sfn_target_policy.json
 }

--- a/security-alerts/iam.tf
+++ b/security-alerts/iam.tf
@@ -92,7 +92,7 @@ resource "aws_iam_role" "sfn_sechub_role" {
         Action : "sts:AssumeRole",
         Condition : {
           ArnLike : {
-            "aws:SourceArn" : "arn:aws:states:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.step_function_name}"
+            "aws:SourceArn" : "arn:aws:states:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:stateMachine:*"
           },
           StringEquals : {
             "aws:SourceAccount" : "${data.aws_caller_identity.current.account_id}"

--- a/security-alerts/iam.tf
+++ b/security-alerts/iam.tf
@@ -167,11 +167,6 @@ resource "aws_iam_role" "sfn_target_role" {
         },
         Action : "sts:AssumeRole",
         Condition : {
-          ArnLike : {
-            "aws:SourceArn" : ["arn:aws:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule:${var.sechub_rule_name}",
-              "arn:aws:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule:${var.sechub_nessus_rule_name}"
-            ]
-          },
           StringEquals : {
             "aws:SourceAccount" : "${data.aws_caller_identity.current.account_id}"
           }

--- a/security-alerts/step_function.tf
+++ b/security-alerts/step_function.tf
@@ -1,6 +1,6 @@
 resource "aws_sfn_state_machine" "sechub_state_machine" {
-  name     = "sechub_state_machine"
-  role_arn = aws_iam_role.sfn_sechub_role
+  name     = var.step_function_name
+  role_arn = aws_iam_role.sfn_sechub_role.arn
   definition = jsonencode({
     Comment : "A description of my state machine",
     StartAt : "check if new or repeated finding from Nessus",

--- a/security-alerts/step_function.tf
+++ b/security-alerts/step_function.tf
@@ -1,0 +1,35 @@
+resource "aws_sfn_state_machine" "sechub_state_machine" {
+  name     = "sechub_state_machine"
+  role_arn = aws_iam_role.sfn_sechub_role
+  definition = jsonencode({
+    Comment : "A description of my state machine",
+    StartAt : "check if new or repeated finding from Nessus",
+    States : {
+      "New Finding Check" : {
+        Type : "Choice",
+        Choices : [
+          {
+            Variable : "$.detail.findings[0].FirstObservedAt",
+            TimestampEqualsPath : "$.detail.findings[0].LastObservedAt",
+            Next : "SNS Publish"
+          }
+        ],
+        Default : "Success",
+        Comment : "if this is the first time we have seen the finding { alert } else { suppress} "
+      },
+      "SNS Publish" : {
+        Type : "Task",
+        Resource : "arn:aws:states:::sns:publish",
+        Parameters : {
+          "Message.$" : "$",
+          TopicArn : aws_sns_topic.slack_topic.arn
+        },
+        "End" : true,
+        "Comment" : "Publish finding to slack"
+      },
+      "Success" : {
+        "Type" : "Succeed"
+      }
+    }
+  })
+}

--- a/security-alerts/step_function.tf
+++ b/security-alerts/step_function.tf
@@ -3,7 +3,7 @@ resource "aws_sfn_state_machine" "sechub_state_machine" {
   role_arn = aws_iam_role.sfn_sechub_role.arn
   definition = jsonencode({
     Comment : "A description of my state machine",
-    StartAt : "check if new or repeated finding from Nessus",
+    StartAt : "New Finding Check",
     States : {
       "New Finding Check" : {
         Type : "Choice",

--- a/security-alerts/variables.tf
+++ b/security-alerts/variables.tf
@@ -7,3 +7,8 @@ variable "iam_role_path" {
   type    = string
   default = "/delegatedadmin/developer/"
 }
+
+variable "step_function_name" {
+  type    = string
+  default = "sechub_state_machine"
+}

--- a/security-alerts/variables.tf
+++ b/security-alerts/variables.tf
@@ -12,3 +12,13 @@ variable "step_function_name" {
   type    = string
   default = "sechub_state_machine"
 }
+
+variable "sechub_rule_name" {
+  type    = string
+  default = "sechub-findings-to-lambda"
+}
+
+variable "sechub_nessus_rule_name" {
+  type    = string
+  default = "sechub-findings-to-lambda-nessus"
+}


### PR DESCRIPTION
## Fixes Issue: 
[BATSAD-937](https://jiraent.cms.gov/browse/BATSAD-937)

## Description:

Adds a Step Function between the EventBridge Rules that listen for SecHub findings to filter out non-new SecurityHub alerts


## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [x] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.
