### PR TITLE
Fix: KMS and SNS topic permissions for cloudwatch service principal

### DIFF
--- a/security-alerts/cloudwatch.tf
+++ b/security-alerts/cloudwatch.tf
@@ -39,6 +39,6 @@ resource "aws_cloudwatch_metric_alarm" "sechub_statemachine_alarm" {
   period              = "60"
   alarm_actions       = [aws_sns_topic.slack_topic.arn]
   dimensions          = {
-    StateMachineArn = aws_sfn_state_machine.name
+    StateMachineArn = aws_sfn_state_machine.sechub_state_machine.name
   }
 }

--- a/security-alerts/cloudwatch.tf
+++ b/security-alerts/cloudwatch.tf
@@ -31,11 +31,14 @@ resource "aws_cloudwatch_metric_alarm" "sechub_statemachine_alarm" {
   alarm_name          = "sechub_statemachine_alarm"
   metric_name         = "ExecutionsFailed"
   namespace           = "AWS/States"
-  threshold           = "0"
+  threshold           = "1"
   statistic           = "Sum"
-  comparison_operator = "GreaterThanThreshold"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
   datapoints_to_alarm = "1"
   evaluation_periods  = "1"
   period              = "60"
   alarm_actions       = [aws_sns_topic.slack_topic.arn]
+  dimensions          = {
+    StateMachineArn = aws_sfn_state_machine.name
+  }
 }

--- a/security-alerts/cloudwatch.tf
+++ b/security-alerts/cloudwatch.tf
@@ -39,6 +39,6 @@ resource "aws_cloudwatch_metric_alarm" "sechub_statemachine_alarm" {
   period              = "60"
   alarm_actions       = [aws_sns_topic.slack_topic.arn]
   dimensions          = {
-    StateMachineArn = aws_sfn_state_machine.sechub_state_machine.name
+    StateMachineArn = aws_sfn_state_machine.sechub_state_machine.arn
   }
 }

--- a/security-alerts/kms.tf
+++ b/security-alerts/kms.tf
@@ -26,6 +26,7 @@ data "aws_iam_policy_document" "kms_key" {
       identifiers = [
         "events.amazonaws.com",
         "chatbot.amazonaws.com",
+        "cloudwatch.amazonaws.com"
       ]
     }
   }

--- a/security-alerts/sns.tf
+++ b/security-alerts/sns.tf
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
 
     principals {
       type        = "Service"
-      identifiers = ["events.amazonaws.com"]
+      identifiers = ["events.amazonaws.com", "cloudwatch.amazonaws.com"]
     }
 
     resources = [


### PR DESCRIPTION
## Fixes Issue: [BATSAD-1128](https://jiraent.cms.gov/browse/BATSAD-1128)

## Description:

Cloudwatch Alarms dont appear to be firing, likely due to a permissioning issue: "CloudWatch Alarms is not authorized to perform: SNS:Publish on resource:......"  This should correct that. Relevant: https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-receive-sns-for-alarm-trigger/

## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [x] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.
