### PR TITLE
BATSAD-1127: Ingest AWS GuardDuty to S3

### DIFF
--- a/security-alerts/guardduty.tf
+++ b/security-alerts/guardduty.tf
@@ -2,7 +2,7 @@ data "aws_guardduty_detector" "cms_cloud_gd" {}
 
 resource "aws_guardduty_publishing_destination" "s3-export" {
   detector_id     = data.aws_guardduty_detector.cms_cloud_gd.id
-  destination_arn = data.aws_s3_bucket.cms_cloud_logs.arn
+  destination_arn = "${data.aws_s3_bucket.cms_cloud_logs.arn}/guardduty/"
   kms_key_arn     = aws_kms_key.gd_export_kms_key.arn
 }
 

--- a/security-alerts/guardduty.tf
+++ b/security-alerts/guardduty.tf
@@ -9,3 +9,8 @@ resource "aws_guardduty_publishing_destination" "s3-export" {
 data "aws_s3_bucket" "cms_cloud_logs" {
   bucket = "cms-cloud-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
 }
+
+resource "aws_s3_bucket_object" "guardduty_directory" {
+    bucket  = "${data.aws_s3_bucket.cms_cloud_logs.id}"
+    key     =  "guardduty/"
+}

--- a/security-alerts/guardduty.tf
+++ b/security-alerts/guardduty.tf
@@ -3,7 +3,7 @@ data "aws_guardduty_detector" "cms_cloud_gd" {}
 resource "aws_guardduty_publishing_destination" "s3-export" {
   detector_id     = aws_guardduty_detector.cms_cloud_gd.id
   destination_arn = aws_s3_bucket.cms_cloud_logs.arn
-  kms_key_arn     = aws_kms_key.gd_key.arn
+  kms_key_arn     = aws_kms_key.gd_export_kms_key.arn
 }
 
 data "aws_s3_bucket" "cms_cloud_logs" {

--- a/security-alerts/guardduty.tf
+++ b/security-alerts/guardduty.tf
@@ -1,8 +1,8 @@
 data "aws_guardduty_detector" "cms_cloud_gd" {}
 
 resource "aws_guardduty_publishing_destination" "s3-export" {
-  detector_id     = aws_guardduty_detector.cms_cloud_gd.id
-  destination_arn = aws_s3_bucket.cms_cloud_logs.arn
+  detector_id     = data.aws_guardduty_detector.cms_cloud_gd.id
+  destination_arn = data.aws_s3_bucket.cms_cloud_logs.arn
   kms_key_arn     = aws_kms_key.gd_export_kms_key.arn
 }
 

--- a/security-alerts/guardduty.tf
+++ b/security-alerts/guardduty.tf
@@ -1,0 +1,11 @@
+data "aws_guardduty_detector" "cms_cloud_gd" {}
+
+resource "aws_guardduty_publishing_destination" "test" {
+  detector_id     = aws_guardduty_detector.cms_cloud_gd.id
+  destination_arn = aws_s3_bucket.cms_cloud_logs.arn
+  kms_key_arn     = aws_kms_key.gd_key.arn
+}
+
+data "aws_s3_bucket" "cms_cloud_logs" {
+  bucket = "cms-cloud-${data.aws_caller_identity.current.account_id}-us-east-1"
+}

--- a/security-alerts/guardduty.tf
+++ b/security-alerts/guardduty.tf
@@ -1,11 +1,11 @@
 data "aws_guardduty_detector" "cms_cloud_gd" {}
 
-resource "aws_guardduty_publishing_destination" "test" {
+resource "aws_guardduty_publishing_destination" "s3-export" {
   detector_id     = aws_guardduty_detector.cms_cloud_gd.id
   destination_arn = aws_s3_bucket.cms_cloud_logs.arn
   kms_key_arn     = aws_kms_key.gd_key.arn
 }
 
 data "aws_s3_bucket" "cms_cloud_logs" {
-  bucket = "cms-cloud-${data.aws_caller_identity.current.account_id}-us-east-1"
+  bucket = "cms-cloud-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
 }

--- a/security-alerts/guardduty.tf
+++ b/security-alerts/guardduty.tf
@@ -10,7 +10,7 @@ data "aws_s3_bucket" "cms_cloud_logs" {
   bucket = "cms-cloud-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
 }
 
-resource "aws_s3_bucket_object" "guardduty_directory" {
+resource "aws_s3_object" "guardduty_directory" {
     bucket  = "${data.aws_s3_bucket.cms_cloud_logs.id}"
     key     =  "guardduty/"
 }

--- a/security-alerts/kms.tf
+++ b/security-alerts/kms.tf
@@ -85,7 +85,7 @@ data "aws_iam_policy_document" "gd_export_kms_key" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/PantherLogProcessingRole-${var.account_name}"
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${var.iam_role_path}PantherLogProcessingRole-${var.account_name}"
       ]
     }
   }

--- a/security-alerts/kms.tf
+++ b/security-alerts/kms.tf
@@ -44,3 +44,63 @@ resource "aws_kms_alias" "kms_key" {
   name          = "alias/batcave-sec-alerts"
   target_key_id = aws_kms_key.kms_key.id
 }
+
+## GuardDuty S3 Export KMS Key
+
+data "aws_iam_policy_document" "gd_export_kms_key" {
+
+  statement {
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+
+  statement {
+    sid = "Allow GuardDuty to encrypt findings"
+    actions = [
+      "kms:GenerateDataKey"
+    ]
+
+    resources = [
+      "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["guardduty.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid = "Allow key access for Panther"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/PantherLogProcessingRole-${var.account_name}"
+      ]
+    }
+  }
+
+}
+
+resource "aws_kms_key" "gd_export_kms_key" {
+  deletion_window_in_days = 7
+  description             = "GD S3 Export KMS Key"
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.gd_export_kms_key.json
+
+}
+
+resource "aws_kms_alias" "gd_export_kms_key" {
+  name          = "alias/batcave-gd-export-s3"
+  target_key_id = aws_kms_key.gd_export_kms_key.id
+}

--- a/security-alerts/kms.tf
+++ b/security-alerts/kms.tf
@@ -88,6 +88,9 @@ data "aws_iam_policy_document" "gd_export_kms_key" {
         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${var.iam_role_path}PantherLogProcessingRole-${var.account_name}"
       ]
     }
+    resources = [
+      "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"
+    ]
   }
 
 }


### PR DESCRIPTION
## Fixes Issue: [BATSAD-1127](https://jiraent.cms.gov/browse/BATSAD-1127)

## Description:

Configures GuardDuty S3 export to the cms-cloud-logging buckets to be ingested into Panther

## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [X] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.
