### PR TITLE
feat: disable guardduty direct to chatbot

### DIFF
--- a/security-alerts/events.tf
+++ b/security-alerts/events.tf
@@ -66,31 +66,3 @@ resource "aws_cloudwatch_event_target" "nessus" {
   arn       = aws_sfn_state_machine.sechub_state_machine.arn
   role_arn  = aws_iam_role.sfn_target_role.arn
 }
-
-# GuardDuty
-resource "aws_cloudwatch_event_rule" "guardduty" {
-  name        = "guardduty-findings-to-lambda"
-  description = "Sends GuardDuty findings to a Slack Lambda"
-
-  event_pattern = <<EOF
-{
-  "source": [
-    "aws.guardduty"
-  ],
-  "detail-type": [
-    "GuardDuty Finding"
-  ],
-  "detail": {
-    "severity": [
-      { "numeric": [ ">", 3.9 ] }
-    ]
-  }
-}
-EOF
-}
-
-resource "aws_cloudwatch_event_target" "guardduty" {
-  rule      = aws_cloudwatch_event_rule.guardduty.name
-  target_id = aws_cloudwatch_event_rule.guardduty.name
-  arn       = aws_sns_topic.slack_topic.id
-}


### PR DESCRIPTION
## Fixes Issue: [BATSAD-1127](https://jiraent.cms.gov/browse/BATSAD-1127)

## Description:

Disables GuardDuty events direct to AWS Chatbot, as we now consume/enrich them via Panther. See https://github.com/CMS-Enterprise/batcave-detections-as-code/pull/10 for more information

## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [x] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.
