### PR TITLE
No need job scheduler

### DIFF
--- a/role/main.tf
+++ b/role/main.tf
@@ -186,6 +186,5 @@ resource "aws_iam_role_policy_attachment" "api_policy" {
 resource "aws_iam_role_policy_attachment" "job_scheduler_policy" {
   count = var.create_job_scheduler_policy_and_role ? 1 : 0
   role       = aws_iam_role.job-scheduler-service-role.name
-  count = var.create_job_scheduler_policy_and_role ? 1 : 0
   policy_arn = aws_iam_policy.job-scheduler-policy.arn
 }

--- a/role/main.tf
+++ b/role/main.tf
@@ -30,6 +30,7 @@ resource "aws_iam_role" "api-service-role" {
 }
 
 resource "aws_iam_role" "job-scheduler-service-role" {
+  count = var.create_job_scheduler_policy_and_role ? 1 : 0
   name = "${var.GroupName}-job-scheduler-service-role"
   depends_on = [
       aws_iam_policy.job-scheduler-policy
@@ -122,6 +123,7 @@ locals {
 }
 
 resource "aws_iam_policy" "job-scheduler-policy" {
+  count = var.create_job_scheduler_policy_and_role ? 1 : 0
   name        = "${var.GroupName}-job-scheduler-policy"
   path        = "/delegatedadmin/developer/"
 
@@ -182,6 +184,8 @@ resource "aws_iam_role_policy_attachment" "api_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "job_scheduler_policy" {
+  count = var.create_job_scheduler_policy_and_role ? 1 : 0
   role       = aws_iam_role.job-scheduler-service-role.name
+  count = var.create_job_scheduler_policy_and_role ? 1 : 0
   policy_arn = aws_iam_policy.job-scheduler-policy.arn
 }

--- a/role/variables.tf
+++ b/role/variables.tf
@@ -50,3 +50,9 @@ variable "permissions_boundary" {
   default     = null
   description = "IAM Role Permissions Boundary, if required."
 }
+
+variable "make_job_scheduler_policy_and_role" {
+  type        = bool
+  default     = true
+  description = "Create job scheduler policy, attachment, and role, if required"
+}


### PR DESCRIPTION
## Fixes Issue: [link to JIRA ticket](http://example.com)

## Description:
Signal team no longer uses the job-scheduler policy and role. To preserve default behavior I have added an optional boolean variable to determine is those resources can be created.

## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [x] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.
